### PR TITLE
Add 3 day retention env variable

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,7 @@ processes = []
 [env]
   PORT = "8080"
   LP_BEHIND_PROXY = "yes"
+  LP_RETENTION_DAYS = "3"
   LITESTREAM_REGION = "us-west-000"
   DB_REPLICA_URL = "s3://logs-tinypilotkvm-com.s3.us-west-000.backblazeb2.com"
 


### PR DESCRIPTION
Deletes log entries older than 3 days.
Wraps the existing LogPaste image with a cleanup script.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/logpaste-fly.io/5"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>